### PR TITLE
Fixed album background duplicating and obscuring buttons

### DIFF
--- a/.config/swaync/themes/nova-dark/central_control.css
+++ b/.config/swaync/themes/nova-dark/central_control.css
@@ -243,6 +243,10 @@ progressbar {
     font-size: 0.8rem;
 }
 
+picture.mpris-background {
+  opacity: 0;
+}
+
 /* Volume */
 .widget-volume {
   background: @background-sec;


### PR DESCRIPTION
I had the same issue outlined in #21.

Not sure if this is intended behavior, but the duplicated album art does obscure the buttons/rest of the widget like the issue says, so I added a couple lines of css so that the duplicate is hidden on the mpris widget.

### Screenshots attached below:

**Before:**
<img width="560" height="969" alt="2025-12-30-232329_hyprshot" src="https://github.com/user-attachments/assets/30619da0-808e-42fb-b831-1f45691b71aa" />
**After:**
<img width="549" height="974" alt="2025-12-30-232354_hyprshot" src="https://github.com/user-attachments/assets/7a993533-2e7f-4c98-b0b3-45d27e71288c"/>